### PR TITLE
New docs to reflect WebStorage Option

### DIFF
--- a/sections/api/app-add-listener.js
+++ b/sections/api/app-add-listener.js
@@ -27,10 +27,9 @@ module.exports = (attrs) => {
         </div>
         <div>
           <code-style>app.addListener</code-style> adds a function that
-          triggers on every action call. This can be used to save state in
-          localstorage, or to debug the state of the store as actions are
-          called. This should not be used to update the DOM, only trigger
-          side-effects.
+          triggers on every action call. This can be used to debug the
+          state of the store as actions are called. This should not be used to
+          update the DOM, only trigger side-effects.
           <br/><br/>
           It takes in one argument, a function, which will have the new
           <code-style>store</code-style> value,

--- a/sections/api/constructor.js
+++ b/sections/api/constructor.js
@@ -8,7 +8,12 @@ const html = Tram.html({
 
 const code = `
 const Tram = require('tram-one')
-const app = new Tram({defaultRoute: '/'})
+
+const app = new Tram({
+  defaultRoute: '/',
+  webStorage: localStorage
+})
+
 const html = Tram.html()
 
 const home = (state) => {
@@ -33,8 +38,21 @@ module.exports = (attrs) => {
           object, for different configurations.
           <br/><br/>
           <code-style>defaultRoute</code-style> is the path that Tram-One will
-          go to when no others match. <br/>
-          By default, this is <code-style>'/404'</code-style>
+          go to when no others match. This can be useful as an error page, or
+          to force all routes to go to a home page.
+          <br/>
+          By default, this is <code-style>'/404'</code-style>, so adding an
+          error page to <code-style>'/404'</code-style> will cause all invalid
+          routes to navigate to that page.
+          <br/><br/>
+          <code-style>webStorage</code-style> is the object that state will
+          persist in.
+          <br/>
+          By default, this is <code-style>sessionStorage</code-style>, so app
+          state will persist between page reloads, but not when the page is
+          closed and re-opened. You can also set it to
+          <code-style>localStorage</code-style>, or your own plain javascript
+          object.
         </div>
         <div>
           <code-block background=${attrs.background} filename="app.js">

--- a/sections/features/state-management.js
+++ b/sections/features/state-management.js
@@ -1,6 +1,7 @@
 const Tram = require('tram-one')
 const html = Tram.html({
   'section-block': require('../../elements/section-block'),
+  'code-style': require('../../elements/code-style'),
   'code-block': require('../../elements/code-block'),
   'anchor-clip': require('../../elements/anchor-clip')
 })
@@ -43,7 +44,8 @@ module.exports = (attrs) => {
           <anchor-clip tag="h3" id="state-management" header="State Management"/>
         </div>
         <div>
-          Tram-One follows a Flux-like architecture model with Hover-Engine.
+          Tram-One follows a Flux-like architecture model with
+          <a href="https://github.com/Tram-One/hover-engine">Hover-Engine</a>.
           If you're familiar with redux, it's very similar.
         </div>
         <div empty />
@@ -75,7 +77,8 @@ module.exports = (attrs) => {
         <div empty />
         <div>
           Now we can reference the store values, and call these actions on our
-          page. Pages have access to the different stores, and an actions
+          page. Pages have access to the different stores, and an
+          <code-style>actions</code-style>
           object with all the methods we defined before.
         </div>
         <div>


### PR DESCRIPTION
## Summary
With the release of 5.2, webStorage is a new constructor parameter. Using `addListener` to set localstorage is now discouraged.